### PR TITLE
fix(bookmark): point the author link to the message author as opposed to the reactor

### DIFF
--- a/breadbot/util/bookmark.py
+++ b/breadbot/util/bookmark.py
@@ -37,7 +37,7 @@ async def maybe_serve_bookmark_request(reaction: discord.RawReactionActionEvent)
         logger.error("Failed to fetch message to serve bookmark request.", exc_info=e)
         return
 
-    author_line = f"Author: {member.mention}"
+    author_line = f"Author: {message.author.mention}"
     channel_line = f"Channel: {channel_or_thread.jump_url}"
     link_line = f"Message Link: {message.jump_url}"
     if len(message.content) <= MAX_EXCERPT_LENGTH:


### PR DESCRIPTION
Minor issue that makes the bookmark author link refer to the bookmarker as opposed to the author of the original message. Tested the same as the previous PR.