### PR TITLE
feat(bookmark): allow deleting bookmarks with an appropriate message reaction

### DIFF
--- a/breadbot/bot.py
+++ b/breadbot/bot.py
@@ -12,7 +12,10 @@ from tortoise import Tortoise
 
 from breadbot import BASE_DIR
 from breadbot.models import Guild
-from breadbot.util.bookmark import maybe_serve_bookmark_request
+from breadbot.util.bookmark import (
+    maybe_serve_bookmark_request,
+    maybe_delete_bookmark,
+)
 from breadbot.util.channel_sorting import reposition_channel
 from breadbot.util.discord_objects import (
     get_log_channel,
@@ -147,13 +150,15 @@ async def on_guild_channel_update(before, after):
     )
     await reposition_channel(after, categories)
 
+
 @bot.event
 async def on_raw_reaction_add(payload):
     """
-    Check for and serve a bookmark request.
-    
+    Check for and serve a bookmark request or a bookmark delete request.
+
     We make use of the 'on_raw_reaction_add' event as opposed to the 'on_reaction_add' event
     cuz the latter only triggers for reactions that happen on messages present in the message
     cache whereas the former is triggered for reactions on every message, no matter how old.
     """
     await maybe_serve_bookmark_request(payload)
+    await maybe_delete_bookmark(bot, payload)

--- a/breadbot/util/bookmark.py
+++ b/breadbot/util/bookmark.py
@@ -1,25 +1,35 @@
+from typing import Optional
+
 import discord
 import logging
 
 logger = logging.getLogger()
 
-BOOKMARK_EMOJI = '🔖'
+BOOKMARK_EMOJI = "🔖"
+BOOKMARK_EMBED_TITLE = "Bookmark"
 MAX_EXCERPT_LENGTH = 200
+WASTEBASKET_EMOJI = "🗑️"
 
-async def maybe_serve_bookmark_request(reaction: discord.RawReactionActionEvent):
+
+async def maybe_serve_bookmark_request(
+    reaction: discord.RawReactionActionEvent,
+):
     """
     Check if a message reaction is a bookmark (🔖) and DM the reactor
     an excerpt of the message if so.
     """
 
+    # Check if the reaction was made with the unicode bookmark emoji
+    if (
+        not reaction.emoji.is_unicode_emoji()
+        or reaction.emoji.name != BOOKMARK_EMOJI
+    ):
+        return
+
     # Check if no member is associated with the reaction (this would be the case
     # when the reaction is made on a message outside the guild, eg: in DMs) and
     # also ensure that the member is not a bot
     if reaction.member is None or reaction.member.bot:
-        return
-
-    # Check if the reaction was made with the unicode bookmark emoji
-    if not reaction.emoji.is_unicode_emoji() or reaction.emoji.name != BOOKMARK_EMOJI:
         return
 
     member = reaction.member
@@ -34,7 +44,9 @@ async def maybe_serve_bookmark_request(reaction: discord.RawReactionActionEvent)
         # this method.
         message = await channel_or_thread.fetch_message(reaction.message_id)
     except Exception as e:
-        logger.error("Failed to fetch message to serve bookmark request.", exc_info=e)
+        logger.error(
+            "Failed to fetch message to serve bookmark request.", exc_info=e
+        )
         return
 
     author_line = f"Author: {message.author.mention}"
@@ -45,11 +57,93 @@ async def maybe_serve_bookmark_request(reaction: discord.RawReactionActionEvent)
     else:
         content = f"{message.content[:MAX_EXCERPT_LENGTH]}..."
 
-    embed = discord.Embed(title=f"Bookmark")
-    embed.add_field(name="Details", value=f"{author_line}\n{channel_line}\n{link_line}", inline=False)
+    embed = discord.Embed(title=BOOKMARK_EMBED_TITLE)
+    embed.add_field(
+        name="Details",
+        value=f"{author_line}\n{channel_line}\n{link_line}",
+        inline=False,
+    )
     embed.add_field(name="Excerpt", value=content, inline=False)
 
     try:
-        await member.send(embed=embed)
+        message = await member.send(embed=embed)
     except Exception as e:
-        logger.error("Failed DM-ing bookmark to member", exc_info=e)
+        logger.error("Failed DM-ing bookmark to member.", exc_info=e)
+
+    try:
+        # Add wastebasket reaction for better UX for deleting the bookmark.
+        await message.add_reaction(WASTEBASKET_EMOJI)
+    except Exception as e:
+        logger.error(
+            "Failed adding wastebasket reaction on bookmark.", exc_info=e
+        )
+
+
+async def maybe_delete_bookmark(
+    bot: discord.Client,
+    reaction: discord.RawReactionActionEvent,
+):
+    """
+    Check if the reaction is the wastebasket emoji (🗑️) on a DM bookmark
+    and delete the bookmark if so.
+    """
+
+    # Check if the reaction is the wastebasket emoji. Return if not.
+    if (
+        not reaction.emoji.is_unicode_emoji()
+        or reaction.emoji.name != WASTEBASKET_EMOJI
+    ):
+        return
+
+    # Check if the reaction has a member associated with it. If yes, it was added
+    # in a guild i.e. not in DMs with the bot, so return.
+    if reaction.member is not None:
+        return
+
+    # If the reaction was added by the bot, return.
+    if bot.user is None or reaction.user_id == bot.user.id:
+        return
+
+    try:
+        dm_channel = await bot.fetch_channel(reaction.channel_id)
+    except Exception as e:
+        logger.error(
+            "Failed to fetch DM channel for serving a bookmark delete request.",
+            exc_info=e,
+        )
+        return
+
+    # If the channel is not a private DM, return.
+    if not isinstance(dm_channel, discord.DMChannel):
+        return
+
+    try:
+        message = await dm_channel.fetch_message(reaction.message_id)
+    except Exception as e:
+        logger.error(
+            "Failed to fetch message for serving a bookmark delete request.",
+            exc_info=e,
+        )
+        return
+
+    # If the message wasn't set by the bot, or if it has less than or more than
+    # 1 embeds i.e. it's potentially not a bookmark, return.
+    if (
+        not message.author.bot
+        or message.author.id != bot.user.id
+        or len(message.embeds) != 1
+    ):
+        return
+
+    # If the embed is not a bookmark embed, return.
+    if message.embeds[0].title != BOOKMARK_EMBED_TITLE:
+        return
+
+    try:
+        # We have confirmed this is indeed a bookmark message by the bot, so delete it.
+        await message.delete()
+    except Exception as e:
+        logger.error(
+            "Error deleting the bookmark message when serving a delete request.",
+            exc_info=e,
+        )

--- a/breadbot/util/bookmark.py
+++ b/breadbot/util/bookmark.py
@@ -69,6 +69,7 @@ async def maybe_serve_bookmark_request(
         message = await member.send(embed=embed)
     except Exception as e:
         logger.error("Failed DM-ing bookmark to member.", exc_info=e)
+        return
 
     try:
         # Add wastebasket reaction for better UX for deleting the bookmark.


### PR DESCRIPTION
## Description of Changes
This PR adds an auxiliary feature on top of the Bookmarking feature (added in #4) that allows the user to delete bookmarks by reacting to them with the wastebasket (🗑️) emoji.

## Motivation
Some bookmarks may outlive their usefulness and one might just want to do a general cleanup or get rid of accidental bookmarks.

## Testing
Done with a personal bot account. The following was verified :-
- For every bookmark, the bot adds a '🗑️' reaction for a better UX when deleting bookmarks.
- When the user reacts with a '🗑️' to a bookmark, the bot deletes it.
- The bot only deletes bookmarks

## Notes
- The call to fetch the channel is probably redundant and there's probably a way to eliminate it by using low-level discord.py interfaces to fetch the message as opposed to using the channel object to do so. Might take this up later.